### PR TITLE
Adding explicit test for array conversion, removing dead code

### DIFF
--- a/src/helpers/convert-to-type.js
+++ b/src/helpers/convert-to-type.js
@@ -7,38 +7,29 @@ export default function convert (toType, value) {
     throw new Error('No value provided')
   }
 
-  if (Array.isArray(value)) {
-    // If value passed in is an array, then recurse over the array.
+  // Convert to new colour mode as long as
+  // source + destination colour modes are different.
 
-    value.map((colour) => (
-      convert(toType, colour)
-    ))
-    return colour
+  const fromType = determineType(value)
 
-  } else {
-    // If value is NOT an array, convert to new colour mode as long as
-    // source + destination colour modes are different.
+  if (fromType === toType) {
+    return value
+  }
 
-    const fromType = determineType(value)
-
-    if (fromType === toType) {
-      return value
-    }
-
-    let conversionFunction = conversions[fromType][toType]
-    if (conversionFunction) return conversionFunction(value)
-
-    conversionFunction = (colour) => {
-      const chain = getChain(fromType, toType)
-      const functionChain = chain.slice(1).reduce((acc, mode) => {
-        acc.fns.push(conversions[acc.last][mode])
-        acc.last = mode
-        return acc
-      }, {last: fromType, fns: []}).fns
-      return functionChain.reduce((acc, fn) => fn(acc), colour)
-    }
-
+  let conversionFunction = conversions[fromType][toType]
+  if (conversionFunction) {
     return conversionFunction(value)
   }
 
+  conversionFunction = (colour) => {
+    const chain = getChain(fromType, toType)
+    const functionChain = chain.slice(1).reduce((acc, mode) => {
+      acc.fns.push(conversions[acc.last][mode])
+      acc.last = mode
+      return acc
+    }, { last: fromType, fns: [] }).fns
+    return functionChain.reduce((acc, fn) => fn(acc), colour)
+  }
+
+  return conversionFunction(value)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -19,9 +19,19 @@ describe('Conversion', function () {
       let accuracy = consts.red[fromKey].accuracy[toKey] || 0
 
       describe(fromKey.toUpperCase() + ' > ' + toKey.toUpperCase(), function () {
+        const fromValue = consts.red[fromKey].value
+        const expected = round(consts.red[toKey].value, accuracy)
+
         it(`should return ${accuracy !== 0 ? 'a value close to' : 'the value'} ${JSON.stringify(consts.red[toKey].value)}`, function () {
           assert.deepEqual(
-            round(chroma.convert(consts.red[fromKey].value)[toKey], accuracy), /* === */ round(consts.red[toKey].value, accuracy)
+            round(chroma.convert(fromValue)[toKey], accuracy),
+            expected
+          )
+        })
+        it(`should return ${accuracy !== 0 ? 'a value close to' : 'the value'} ${JSON.stringify(consts.red[toKey].value)} when passed in as an array`, () => {
+          assert.deepEqual(
+            chroma.convert([ fromValue, fromValue ])[toKey].map(value => round(value, accuracy)),
+            [ expected, expected ]
           )
         })
       })


### PR DESCRIPTION
Handling the array case in the helper file `convert-to-type.js` is not necessary, because that case is already handled in the convert operation in `operations/convert.js`.