### PR TITLE
Drop the browser field from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0",
   "description": "A simple set of utility functions for colours.",
   "main": "dist/chromatism.umd.js",
-  "browser": "dist/chromatism.cjs.js",
   "module": "src/operations/index.js",
   "typings": "./index.d.ts",
   "repository": "toish/chromatism",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,5 @@ export default {
   ],
   targets: [
     { dest: pkg.main, format: 'umd' },
-    { dest: pkg.browser, format: 'cjs' }
   ]
 }


### PR DESCRIPTION
I think I made a mistake by adding the browser/CommonJS entry point in the first place.

Having the browser field point to a CommonJS build keeps ESM-aware bundlers from going to the "module" field like we want them to.

For the non-ESM bundlers, the UMD build only adds a couple hundred bytes or so.

I think this should be published as a patch release.