### PR TITLE
Kale Automated Fixes [ Remove return in single expression arrow functions ]

### DIFF
--- a/src/conversions/XYZ.js
+++ b/src/conversions/XYZ.js
@@ -40,9 +40,7 @@ export default {
     let Mb = getTransform('BRADFORD')
 
     let resultArray = Mb.map((m) => {
-      return valueArray.reduce((acc, v, key) => {
-        return (m[key] * v) + acc
-      }, 0)
+      return valueArray.reduce((acc, v, key) => (m[key] * v) + acc, 0)
     })
 
     return {

--- a/src/conversions/lms.js
+++ b/src/conversions/lms.js
@@ -8,9 +8,7 @@ export default {
     const Mbi = getTransform('INVERSE_BRADFORD')
 
     const resultArray = Mbi.map((m) => {
-      return valueArray.reduce((acc, v, key) => {
-        return (m[key] * v) + acc
-      }, 0)
+      return valueArray.reduce((acc, v, key) => (m[key] * v) + acc, 0)
     })
 
     return {


### PR DESCRIPTION
Our automated tool found some changes for simplifying things using one of the added ES6 features. 

For an arrow function, it replaced the curly braces and return statement with a direct value or expression. Should help compact the code and reducing nesting

