### PR TITLE
Fix difference returning NaN with grayscale colors

### DIFF
--- a/src/operations/difference.js
+++ b/src/operations/difference.js
@@ -16,7 +16,7 @@ export default function difference (colourRefOne, colourRefTwo, l, c) {
   const da = Lab1.a - Lab2.a
   const db = Lab1.b - Lab2.b
 
-  const dH = Math.sqrt(Math.pow(da, 2) + Math.pow(db, 2) - Math.pow(dC, 2))
+  const dH = Math.sqrt(Math.abs(Math.pow(da, 2) + Math.pow(db, 2) - Math.pow(dC, 2)))
 
   const SL = Lab1.L < 16 ? 0.511 : (0.040975 * Lab1.L) / (1.01765 * Lab1.L)
   const SC = (0.0638 * C1) / (1.0131 * C1)

--- a/test/test.js
+++ b/test/test.js
@@ -270,6 +270,10 @@ describe('Operations', () => {
     assert(close(chroma.difference('#4fc7ff', '#75c2e6'), 202.64118553936103))
   })
 
+  it('should return non NaN value for difference with greyscale colors', () => {
+    assert(!isNaN(chroma.difference('#f0f0f0', '#ffffff')))
+  })
+
   it('should be close to 6500K when temperature is passed the D65 illuminant', () => {
     assert(close(chroma.temperature({ X: 95.047, Y: 100, Z: 108.883 }), 6503.4619534794965))
   })


### PR DESCRIPTION
This PR fixes issue #48 in difference function.

`difference` function returns `NaN` if one of colours provided as argument is garyscale (e.g. `#f0f0f0`, `#4d4d4d`, `#eeeeee`).